### PR TITLE
Fix staticfiles storage backend in settings

### DIFF
--- a/GalleryStorefront/settings.py
+++ b/GalleryStorefront/settings.py
@@ -87,7 +87,7 @@ STORAGES = {
         ),
     },
     "staticfiles": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
 }
 


### PR DESCRIPTION
This pull request fixes the storage backend in settings by replacing `FileSystemStorage` with `StaticFilesStorage`.